### PR TITLE
Strip accents before comparing names

### DIFF
--- a/sphinxext/toptranslators.py
+++ b/sphinxext/toptranslators.py
@@ -15,10 +15,17 @@ from sphinx.errors import ExtensionError
 from sphinx.util.docutils import SphinxDirective
 
 from tempfile import mkdtemp
+import unicodedata
 
 
 TRANSLATORS_MARKER_NAME = "# Translators:"
 
+# https://stackoverflow.com/questions/517923/what-is-the-best-way-to-remove-accents-normalize-in-a-python-unicode-string/518232#518232
+def strip_accents(s):
+    return "".join(
+        c for c in unicodedata.normalize('NFD', s)
+        if unicodedata.category(c) != 'Mn'
+    )
 
 # Workaround due to git-python storing handles after program execution
 def del_rw(action, name, exc):
@@ -141,7 +148,7 @@ class TopTranslators(SphinxDirective):
             top_contributors = get_top_translators(temp_dir, locale).most_common(limit)
 
             if "alphabetical" in order:
-                top_contributors.sort(key=lambda tup: tup[0])
+                top_contributors.sort(key=lambda tup: strip_accents(tup[0]))
             
             return [
                 ContributorSource(

--- a/tests/roots/test-order-alphabetical/index.rst
+++ b/tests/roots/test-order-alphabetical/index.rst
@@ -1,4 +1,4 @@
 .. toptranslators:: wpilibsuite/frc-docs-translations
    :locale: fr
-   :limit: 4
+   :limit: 10
    :order: alphabetical

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,6 +1,7 @@
 import pytest
 import docutils.nodes as nodes
 import re
+from sphinxext.toptranslators import strip_accents
 
 
 @pytest.mark.sphinx("html", testroot="limit")
@@ -36,6 +37,7 @@ def test_order_alphabetical(html_contexts):
 
     for item in items:
         name = re.search(r"(.*) - (.*?) contribution", item.astext()).group(1)
+        name = strip_accents(name)
         if prev_name == None:
             prev_name = name
             continue


### PR DESCRIPTION
Fixes an issue someone mentioned on Discord.

Names are currently sorted based on their unicode value. This means that all names that start with accented characters will come last.

This PR strips accents from names before comparing them.